### PR TITLE
Build OCamldoc: Change Shortcut

### DIFF
--- a/Commands/Build OCamldoc.tmCommand
+++ b/Commands/Build OCamldoc.tmCommand
@@ -15,7 +15,7 @@ open /tmp/index.html</string>
 	<key>inputFormat</key>
 	<string>text</string>
 	<key>keyEquivalent</key>
-	<string>^~@d</string>
+	<string>^h</string>
 	<key>name</key>
 	<string>Build OCamldoc</string>
 	<key>outputCaret</key>

--- a/Commands/Build OCamldoc.tmCommand
+++ b/Commands/Build OCamldoc.tmCommand
@@ -17,7 +17,7 @@ open /tmp/index.html</string>
 	<key>keyEquivalent</key>
 	<string>^~@d</string>
 	<key>name</key>
-	<string>Build Ocamldoc</string>
+	<string>Build OCamldoc</string>
 	<key>outputCaret</key>
 	<string>afterOutput</string>
 	<key>outputFormat</key>

--- a/Commands/Build Ocamldoc.tmCommand
+++ b/Commands/Build Ocamldoc.tmCommand
@@ -1,23 +1,34 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
 	<key>beforeRunningCommand</key>
 	<string>nop</string>
 	<key>command</key>
-	<string>ocamldoc -html -d /tmp "$TM_FILENAME"
+	<string>#!/bin/bash
+[[ -f "${TM_SUPPORT_PATH}/lib/bash_init.sh" ]] &amp;&amp; . "${TM_SUPPORT_PATH}/lib/bash_init.sh"
+
+ocamldoc -html -d /tmp "$TM_FILENAME"
 open /tmp/index.html</string>
 	<key>input</key>
 	<string>none</string>
+	<key>inputFormat</key>
+	<string>text</string>
 	<key>keyEquivalent</key>
 	<string>^~@d</string>
 	<key>name</key>
 	<string>Build Ocamldoc</string>
-	<key>output</key>
-	<string>showAsTooltip</string>
+	<key>outputCaret</key>
+	<string>afterOutput</string>
+	<key>outputFormat</key>
+	<string>text</string>
+	<key>outputLocation</key>
+	<string>toolTip</string>
 	<key>scope</key>
 	<string>source.ocaml</string>
 	<key>uuid</key>
 	<string>7E096535-0E9E-4866-956A-CCE8694F85A8</string>
+	<key>version</key>
+	<integer>2</integer>
 </dict>
 </plist>


### PR DESCRIPTION
Hi,

this pull request changes the shortcut for the item “Build OCamldoc” to a more appropriate one (<kbd>^</kbd> + <kbd>H</kbd>).

Kind regards,
  René
