### PR TITLE
Syntax highlighting fixes.

### DIFF
--- a/Syntaxes/OCaml.plist
+++ b/Syntaxes/OCaml.plist
@@ -1498,7 +1498,7 @@
 			<array>
 				<dict>
 					<key>begin</key>
-					<string>(val)\s+([a-z_][a-zA-Z0-9_']*)\s*(:)</string>
+					<string>(val)\s+([a-z_][a-zA-Z0-9_']*|\(\s*([#!$%&amp;*+./:&lt;=&gt;?@^|~-]+|and|land|lor|lsl|lsr|asr|lxor|mod|or)\s*\))\s*(:)</string>
 					<key>beginCaptures</key>
 					<dict>
 						<key>1</key>
@@ -1514,11 +1514,16 @@
 						<key>3</key>
 						<dict>
 							<key>name</key>
+							<string>keyword.operator.ocaml</string>
+						</dict>
+						<key>4</key>
+						<dict>
+							<key>name</key>
 							<string>punctuation.separator.type-constraint.ocaml</string>
 						</dict>
 					</dict>
 					<key>end</key>
-					<string>(?=\b(type|val|external|class|module|end)\b)|^\s*$</string>
+					<string>(?=\s*\b(type|val|external|class|module|end)\b)|^\s*$</string>
 					<key>name</key>
 					<string>meta.module.signature.val.ocaml</string>
 					<key>patterns</key>

--- a/Syntaxes/OCaml.plist
+++ b/Syntaxes/OCaml.plist
@@ -152,7 +152,7 @@
 		</dict>
 		<dict>
 			<key>begin</key>
-			<string>(\(|\s)(?=fun\s)</string>
+			<string>(\(|\s)(?=fun\b)</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>1</key>
@@ -177,7 +177,7 @@
 			<array>
 				<dict>
 					<key>begin</key>
-					<string>(?&lt;=(\(|\s))(fun)\s</string>
+					<string>(?&lt;=(\(|\s))(fun)\b</string>
 					<key>beginCaptures</key>
 					<dict>
 						<key>2</key>

--- a/Syntaxes/OCaml.plist
+++ b/Syntaxes/OCaml.plist
@@ -1275,7 +1275,7 @@
 				</dict>
 				<dict>
 					<key>begin</key>
-					<string>(?=[^\\])(")</string>
+					<string>(")(?:(?&lt;!\x27")(?&lt;!\x27\x5c")|(?!\x27))</string>
 					<key>end</key>
 					<string>"</string>
 					<key>name</key>


### PR DESCRIPTION
Previously, the strings `'"'` and `'\"'` (literal, incl. the single quotes and backslash) were misdetected as starting a string inside comment blocks.