### PR TITLE
Fix bug when ocamlyacc file starts with comment

### DIFF
--- a/Syntaxes/OCamlyacc.tmLanguage
+++ b/Syntaxes/OCamlyacc.tmLanguage
@@ -103,11 +103,11 @@
 		</dict>
 		<dict>
 			<key>include</key>
-			<string>source.ocaml</string>
+			<string>#comments</string>
 		</dict>
 		<dict>
 			<key>include</key>
-			<string>#comments</string>
+			<string>source.ocaml</string>
 		</dict>
 		<dict>
 			<key>match</key>


### PR DESCRIPTION
If the ocamlyacc file begins with a multiline comment (`/*`), the `include: source.ocaml` rule gets activated, and parses it as a `/` operator followed by more pure ocaml syntax. By moving the `include: #comments` rule higher up, it will be given precedence instead.

See https://github.com/sublimehq/Packages/pull/3031 for some before/after pictures.